### PR TITLE
Add networked health system with teams

### DIFF
--- a/Assets/Scripts/Game/NetworkGameManager.cs
+++ b/Assets/Scripts/Game/NetworkGameManager.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+using Unity.Netcode;
+
+public class NetworkGameManager : MonoBehaviour
+{
+    public void StartHost()
+    {
+        NetworkManager.Singleton.StartHost();
+    }
+
+    public void StartClient()
+    {
+        NetworkManager.Singleton.StartClient();
+    }
+}

--- a/Assets/Scripts/Game/NetworkGameManager.cs.meta
+++ b/Assets/Scripts/Game/NetworkGameManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/Assets/Scripts/Game/Team.cs
+++ b/Assets/Scripts/Game/Team.cs
@@ -1,0 +1,5 @@
+public enum Team
+{
+    Team1 = 0,
+    Team2 = 1
+}

--- a/Assets/Scripts/Game/Team.cs.meta
+++ b/Assets/Scripts/Game/Team.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aaaaaaaaaaaaaaaaabaaaaaa1111111

--- a/Assets/Scripts/Player/DamageTester.cs
+++ b/Assets/Scripts/Player/DamageTester.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
+using Unity.Netcode;
 
 public class DamageTester : MonoBehaviour
 {
@@ -26,6 +27,6 @@ public class DamageTester : MonoBehaviour
 
     void OnTestDamage(InputAction.CallbackContext context)
     {
-        playerHealth.TakeDamage(25);
+        playerHealth.TakeDamageServerRpc(25, (int)playerHealth.team.Value);
     }
 }

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -1,11 +1,13 @@
 using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
+using Unity.Netcode;
 
-public class PlayerHealth : MonoBehaviour
+public class PlayerHealth : NetworkBehaviour
 {
     public int maxHealth = 200;
-    private float currentHealth;
+    public NetworkVariable<float> currentHealth = new NetworkVariable<float>();
+    public NetworkVariable<int> team = new NetworkVariable<int>();
 
     public GameObject deathMessageUI; // UI-Canvas oder Text
     public Transform respawnPoint;    // Punkt zum Respawnen
@@ -21,34 +23,41 @@ public class PlayerHealth : MonoBehaviour
     private float currentRegenRate;        // steigt stufenweise
 
 
-    private void Start()
+    public override void OnNetworkSpawn()
     {
-        currentHealth = maxHealth;
+        if (IsServer)
+        {
+            currentHealth.Value = maxHealth;
+        }
+
         deathMessageUI.SetActive(false);
         currentRegenRate = regenRate;
 
 
     }
 
-    public int CurrentHealth => Mathf.RoundToInt(currentHealth);   // 2) Property wandelt fürs UI um
+    public int CurrentHealth => Mathf.RoundToInt(currentHealth.Value);
     public int MaxHealth => maxHealth;
 
 
-    public void TakeDamage(int amount)
+    [ServerRpc(RequireOwnership = false)]
+    public void TakeDamageServerRpc(int amount, int attackerTeam)
     {
-        if (currentHealth <= 0) return;
+        if (attackerTeam == team.Value) return;
 
-        timeSinceLastDamage = 0f;   // ← reicht hier
+        if (currentHealth.Value <= 0) return;
 
-        currentHealth -= amount;
+        timeSinceLastDamage = 0f;
 
-        if (currentHealth <= 0)
+        currentHealth.Value -= amount;
+
+        if (currentHealth.Value <= 0)
         {
             Die();
         }
 
         timeInRegen = 0f;
-        currentRegenRate = regenRate;   // Basis
+        currentRegenRate = regenRate;
     }
 
 
@@ -58,17 +67,19 @@ public class PlayerHealth : MonoBehaviour
         controller.enabled = false;
 
         // Meldung anzeigen
-        deathMessageUI.SetActive(true);
+        if (IsOwner)
+            deathMessageUI.SetActive(true);
 
         // Respawn einleiten
-        StartCoroutine(RespawnAfterDelay(2f));
+        if (IsServer)
+            StartCoroutine(RespawnAfterDelay(2f));
     }
 
     IEnumerator RespawnAfterDelay(float delay)
     {
         yield return new WaitForSeconds(delay);
 
-        currentHealth = maxHealth;
+        currentHealth.Value = maxHealth;
         timeSinceLastDamage = 0f;
         timeInRegen = 0f;
         currentRegenRate = regenRate;
@@ -77,18 +88,21 @@ public class PlayerHealth : MonoBehaviour
         transform.position = respawnPoint.position;
         controller.enabled = true;
 
-        deathMessageUI.SetActive(false);
+        if (IsOwner)
+            deathMessageUI.SetActive(false);
     }
 
 
     void Update()
     {
-        if (currentHealth <= 0) return;            // tot
+        if (IsServer && currentHealth.Value <= 0) return;
+
+        if (!IsServer) return;
 
         timeSinceLastDamage += Time.deltaTime;
 
         // ► Regeneration aktiv?
-        if (currentHealth < maxHealth && timeSinceLastDamage >= regenDelay)
+        if (currentHealth.Value < maxHealth && timeSinceLastDamage >= regenDelay)
         {
             // 1) Timer für Ramp-Logik
             timeInRegen += Time.deltaTime;
@@ -101,8 +115,8 @@ public class PlayerHealth : MonoBehaviour
             }
 
             // 3) Heilen
-            currentHealth += currentRegenRate * Time.deltaTime;
-            currentHealth = Mathf.Min(currentHealth, maxHealth);
+            currentHealth.Value += currentRegenRate * Time.deltaTime;
+            currentHealth.Value = Mathf.Min(currentHealth.Value, maxHealth);
         }
     }
 

--- a/Assets/Scripts/Weapons/WeaponController.cs
+++ b/Assets/Scripts/Weapons/WeaponController.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.InputSystem;   // <– neues Input-System
+using Unity.Netcode;
 
 public class WeaponController : MonoBehaviour
 {
@@ -15,6 +16,7 @@ public class WeaponController : MonoBehaviour
     float nextShotTime;          // Cooldown‐Timer
     int currentAmmo;           // Restkugeln im Magazin
     public LayerMask hitMask;     // im Inspector setzen: alles außer „Player“
+    private PlayerHealth shooterHealth;
 
 
     void Awake()
@@ -48,6 +50,8 @@ public class WeaponController : MonoBehaviour
         }
         current = 0;
         ApplyProfile(profiles[current]);
+
+        shooterHealth = GetComponentInParent<PlayerHealth>();
 
         currentAmmo = profiles[current].magazineSize;
 
@@ -126,7 +130,10 @@ public class WeaponController : MonoBehaviour
                             p.range, hitMask, QueryTriggerInteraction.Ignore))
         {
             PlayerHealth hp = hit.collider.GetComponent<PlayerHealth>();
-            if (hp) hp.TakeDamage((int)p.damage);
+            if (hp)
+            {
+                hp.TakeDamageServerRpc((int)p.damage, (int)shooterHealth.team.Value);
+            }
         }
     }
 
@@ -139,7 +146,10 @@ public class WeaponController : MonoBehaviour
                             p.meleeRange, hitMask, QueryTriggerInteraction.Ignore))
         {
             PlayerHealth hp = hit.collider.GetComponent<PlayerHealth>();
-            if (hp) hp.TakeDamage((int)p.meleeDamage);
+            if (hp)
+            {
+                hp.TakeDamageServerRpc((int)p.meleeDamage, (int)shooterHealth.team.Value);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- convert PlayerHealth to `NetworkBehaviour`
- add team-based damage checks via ServerRPC
- update WeaponController and DamageTester to call RPCs
- introduce simple `Team` enum and `NetworkGameManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688607ceec94832baa905f07c9b739a4